### PR TITLE
applications: asset_tracker: bsec: Fix problem with thread creation.

### DIFF
--- a/applications/asset_tracker/src/env_sensors/bsec.c
+++ b/applications/asset_tracker/src/env_sensors/bsec.c
@@ -302,7 +302,7 @@ int env_sensors_init_and_start(struct k_work_q *work_q,
 
 	k_thread_create(&thread, thread_stack, STACKSIZE,
 			(k_thread_entry_t)bsec_thread, NULL, NULL, NULL,
-			CONFIG_SYSTEM_WORKQUEUE_PRIORITY, 0, 0);
+			CONFIG_SYSTEM_WORKQUEUE_PRIORITY, 0, K_NO_WAIT);
 
 	data_ready_cb = cb;
 


### PR DESCRIPTION
Fixes an issue where asset tracker will not compile if
CONFIG_USE_BME680_BSEC=y

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>