### PR TITLE
partition_manager: align with zephyr partition name

### DIFF
--- a/subsys/partition_manager/pm.yml.file_system
+++ b/subsys/partition_manager/pm.yml.file_system
@@ -1,7 +1,7 @@
 #include <autoconf.h>
 
 #ifdef CONFIG_FILE_SYSTEM_LITTLEFS
-littlefs_storage:
-  placement: {after: [mcuboot_storage, app]}
+storage:
+  placement: {after: [app]}
   size: CONFIG_PM_PARTITION_SIZE_LITTLEFS
 #endif

--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -1,5 +1,5 @@
 #include <autoconf.h>
 
 storage:
-  placement: {after: [mcuboot_storage, app]}
+  placement: {after: [app]}
   size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE


### PR DESCRIPTION
To be compatible with zephyr defines.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>