### PR TITLE
add nRF9161DK to sample.yaml

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -4,7 +4,7 @@ tests:
   applications.asset_tracker_v2.nrf_cloud:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns native_posix
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns native_posix
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -13,7 +13,7 @@ tests:
   applications.asset_tracker_v2.nrf_cloud-pgps:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -22,7 +22,7 @@ tests:
   applications.asset_tracker_v2.nrf_cloud-no-agps:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -31,7 +31,7 @@ tests:
   applications.asset_tracker_v2.aws:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns native_posix
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns native_posix
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -43,7 +43,7 @@ tests:
   applications.asset_tracker_v2.aws-pgps:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -54,7 +54,7 @@ tests:
   applications.asset_tracker_v2.aws-all:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -66,7 +66,7 @@ tests:
   applications.asset_tracker_v2.azure:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns native_posix
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns native_posix
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -79,7 +79,7 @@ tests:
   applications.asset_tracker_v2.debug:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns native_posix
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns native_posix
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -89,7 +89,7 @@ tests:
   applications.asset_tracker_v2.debug-memfault:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -100,7 +100,7 @@ tests:
   applications.asset_tracker_v2.memfault:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -111,7 +111,7 @@ tests:
   applications.asset_tracker_v2.low-power:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -128,7 +128,7 @@ tests:
   applications.asset_tracker_v2.lwm2m.low-power:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -137,7 +137,7 @@ tests:
   applications.asset_tracker_v2.lwm2m.debug:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -146,7 +146,7 @@ tests:
   applications.asset_tracker_v2.lwm2m.debug-modem_trace:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -157,7 +157,7 @@ tests:
   applications.asset_tracker_v2.lwm2m.memfault:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -168,7 +168,7 @@ tests:
   applications.asset_tracker_v2.memfault-low-power:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -180,13 +180,13 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build
   applications.asset_tracker_v2.nrf7002ek_wifi-debug:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf" DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   applications.nrf9160.serial_lte_modem:
     build_only: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -11,7 +11,7 @@ tests:
   applications.nrf9160.serial_lte_modem.native_tls:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-native_tls.conf
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
@@ -19,7 +19,7 @@ tests:
   applications.nrf9160.serial_lte_modem.lwm2m_carrier:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-carrier.conf
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns

--- a/samples/nrf9160/https_client/sample.yaml
+++ b/samples/nrf9160/https_client/sample.yaml
@@ -5,5 +5,5 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -5,48 +5,48 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell_debug:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-debug.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.cloud_mqtt_only:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-cloud_mqtt.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.cloud_mqtt_rest:
     build_only: true
     extra_args: CONFIG_MOSH_CLOUD_MQTT=y CONFIG_MOSH_CLOUD_REST=y
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.non_offloading_ip:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.nrf7002ek_wifi:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build
   sample.nrf9160.modem_shell.nrf7002ek_wifi-debug:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG="overlay-nrf7002ek-wifi-scan-only.conf;overlay-debug.conf" DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     tags: ci_build
   sample.nrf9160.modem_shell.esp_wifi:
@@ -54,21 +54,21 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-esp-wifi.conf DTC_OVERLAY_FILE="esp_8266_nrf9160ns.overlay"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.fota:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-app_fota.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.lwm2m_carrier:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-lwm2m_carrier.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.lwm2m:
     build_only: true
@@ -77,7 +77,7 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-lwm2m.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.lwm2m_bootstrap:
     build_only: true
@@ -86,7 +86,7 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-lwm2m_bootstrap.conf"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.lwm2m_pgps:
     build_only: true
@@ -95,14 +95,14 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-lwm2m_pgps.conf;overlay-pgps.conf"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.pgps:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-pgps.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.location_service_ext:
     build_only: true
@@ -111,7 +111,7 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-cloud_mqtt.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.location_service_ext_pgps_nrf7002ek_wifi:
     build_only: true
@@ -120,28 +120,28 @@ tests:
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG="overlay-cloud_mqtt.conf;overlay-pgps.conf;overlay-nrf7002ek-wifi-scan-only.conf" DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.ppp:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-ppp.conf DTC_OVERLAY_FILE="ppp.overlay"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.bt:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-bt.conf DTC_OVERLAY_FILE="bt.overlay"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.rtt:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-rtt.conf
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.thingy91:
     build_only: true
@@ -153,7 +153,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: OVERLAY_CONFIG="overlay-modem-trace.conf;overlay-memfault.conf" DTC_OVERLAY_FILE="nrf9160dk_ext_flash.overlay"
     extra_configs:
      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
@@ -162,7 +162,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_args: OVERLAY_CONFIG="overlay-modem-trace-ram.conf;overlay-memfault.conf"
     extra_configs:
      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="0123456789abcdef0123456789abcdef"
@@ -173,7 +173,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_configs:
       - CONFIG_LOCATION_METHOD_GNSS=y CONFIG_LOCATION_METHOD_CELLULAR=n CONFIG_LOCATION_METHOD_WIFI=y
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
@@ -182,7 +182,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_configs:
       - CONFIG_LOCATION_METHOD_GNSS=n CONFIG_LOCATION_METHOD_CELLULAR=y CONFIG_LOCATION_METHOD_WIFI=y
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
@@ -191,7 +191,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_configs:
       - CONFIG_LOCATION_METHOD_GNSS=n CONFIG_LOCATION_METHOD_CELLULAR=n CONFIG_LOCATION_METHOD_WIFI=y
     extra_args: SHIELD=nrf7002_ek OVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf DTC_OVERLAY_FILE="nrf9160dk_with_nrf7002ek.overlay"
@@ -200,7 +200,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_configs:
       - CONFIG_LOCATION_METHOD_GNSS=y CONFIG_LOCATION_METHOD_CELLULAR=n CONFIG_LOCATION_METHOD_WIFI=n
     tags: ci_build
@@ -208,7 +208,7 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     extra_configs:
       - CONFIG_LOCATION_METHOD_GNSS=n CONFIG_LOCATION_METHOD_CELLULAR=y CONFIG_LOCATION_METHOD_WIFI=n
     tags: ci_build
@@ -219,14 +219,14 @@ tests:
     extra_args: CONFIG_NRF_MODEM_LIB_TRACE=y
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.non_offloading_ip_modem_uart_trace:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf CONFIG_NRF_MODEM_LIB_TRACE=y
     integration_platforms:
       - nrf9160dk_nrf9160_ns
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns nrf9161dk_nrf9161_ns
     tags: ci_build
   sample.nrf9160.modem_shell.thingy91_modem_uart_trace:
     build_only: true


### PR DESCRIPTION
Update sample.yaml with nRF9161DK support for chosen samples.